### PR TITLE
Change private git URL to use public HTTPS.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'coffee-rails', '~> 4.0.0'    # Use CoffeeScript for .js.coffee assets and v
 gem 'jquery-rails'                # Use jquery as the JavaScript library
 gem 'jbuilder', '~> 1.2'          # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'anjlab-bootstrap-rails', '~> 3.0.2.0', :require => 'bootstrap-rails' # Bootstrap
-gem 'pi_piper', :git => 'git@github.com:bguest/pi_piper.git', :branch => 'stub-driver'
+gem 'pi_piper', :git => 'https://github.com/bguest/blinky.git', :branch => 'stub-driver'
 gem 'color'               # Color
 gem 'bitmask_attributes'  # Bitmask
 


### PR DESCRIPTION
Private git URLs aren't supported on Travis CI, as you'll need an SSH key to clone the repository. Using public URLs is recommended for public projects.
